### PR TITLE
Process Draft Inline Images to send properly

### DIFF
--- a/mail-merge/src/Code.js
+++ b/mail-merge/src/Code.js
@@ -217,4 +217,4 @@ function sendEmails(subjectLine, sheet=SpreadsheetApp.getActiveSheet()) {
       .replace(/[\r]/g, '\\r')
       .replace(/[\t]/g, '\\t');
   };
-}
+} 


### PR DESCRIPTION
Resolves Issue #163 -- handling of Inline Images varies between GmailDraft and GmailMessage classes; code changes convert attachments to inlineImages and update <img> tags in HTML Body text to conform to updated usage.