### PR TITLE
Strip out HTML tags in token replacement

### DIFF
--- a/mail-merge/src/Code.js
+++ b/mail-merge/src/Code.js
@@ -179,8 +179,11 @@ function sendEmails(subjectLine, sheet=SpreadsheetApp.getActiveSheet()) {
     let template_string = JSON.stringify(template);
 
     // token replacement
-    template_string = template_string.replace(/{{[^{}]+}}/g, key => {
-      return escapeData_(data[key.replace(/[{}]+/g, "")] || "");
+    template_string = template_string.replace(/{{([^{}]+)}}/g, (_, key) => {
+      // Strip out potential HTML tags, e.g. due to formatting:
+      const cleanKey = key.replace(/<[^>]+>/g, ""); 
+      
+      return escapeData_(data[cleanKey] || "");
     });
     return  JSON.parse(template_string);
   }


### PR DESCRIPTION
Template tags in the HTML body in a message can include HTML tags, which e.g. happens when copying column titles from the spreadsheet over to the composer in Gmail. This change strips out HTML from template keys.

Also changed the regex for matching {{...}}, so that it used a capturing group for the key.